### PR TITLE
Custom Layout bug

### DIFF
--- a/lib/plug_ets_cache/phoenix.ex
+++ b/lib/plug_ets_cache/phoenix.ex
@@ -12,11 +12,11 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           view = view_module(conn)
           template = view_template(conn)
 
-          layout = case layout(conn) do
+          layout = case conn.assigns |> Map.get(:layout, false) do
             false -> false
             {layout_module, layout_template} ->
               format = layout_formats(conn) |> hd
-              {layout_module, "#{layout_template}.#{format}"}
+              {layout_module, "#{layout_template}"}
           end
 
           assigns = Map.merge(conn.assigns, %{conn: conn, layout: layout})


### PR DESCRIPTION
When doing cache response on a render with custom layout, the layout() function will always return a default layout.
Example:
```
conn
    |> render("index.html", layout: {AppName.Web.LayoutView, "test.html"})
    |> cache_response
```
Now changed the code to grab the custom layout, even when a custom is not given, it will fall back on the default layout.
If there is a better solution than this one or I am wrong about this or need more info, just let me know!