### PR TITLE
Do not double set charset in response headers

### DIFF
--- a/lib/plug_ets_cache/plug.ex
+++ b/lib/plug_ets_cache/plug.ex
@@ -21,7 +21,7 @@ defmodule PlugEtsCache.Plug do
 
       result ->
         conn
-        |> put_resp_content_type(result.type)
+        |> put_resp_content_type(result.type, nil)
         |> send_resp(200, result.value)
         |> halt
     end


### PR DESCRIPTION
Without this change, PlugEtsCache will double set the `charset` value in the `content-type` response header.

```
Content-Type: application/xml; charset=utf-8; charset=utf-8
```

_(First reported to us [here](https://github.com/thechangelog/changelog.com/issues/265))_

The problem is `PlugEtsCache.Store.set/3` assumes the `type` being set will be the raw content-type, eg – `text/plain`, `application/xml`, etc.

However, this is never the case because of how Plug's `put_resp_content_type` works. Example:

```elixir
%Plug.Conn{} 
|> Plug.Conn.put_resp_content_type("text/plain") 
|> Plug.Conn.get_resp_header("content-type")
# => ["text/plain; charset=utf-8"]
```

So we're storing `text/plain; charset=utf-8` in the cache and then setting the `charset` again when generating the cached response.

The easy fix to this is to always assume that the `content_type` being cached is the *exact* `content_type` we want returned, and pass a `nil` as the `charset` argument when generating the response.