### PR TITLE
Add possibility to customize the cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ response. Examples:
 cache_response(conn, :timer.hours(1))
 ```
 
+```elixir
+cache_response(conn, ttl: :timer.minutes(45))
+```
+
+### Using a custom cache key
+
+If you need greater control over the key used to cache the request you can use a custom function to build the cache key.
+The function needs to accept one argument, the `Plug.Conn` struct, and return the key.
+
+```elixir
+cache_response(conn, [cache_key: fn conn -> conn.request_path end, ttl: :timer.minutes(10)])
+```
+
 ## Documentation
 
 The docs can be found at [https://hexdocs.pm/plug_ets_cache](https://hexdocs.pm/plug_ets_cache).

--- a/lib/plug_ets_cache/phoenix.ex
+++ b/lib/plug_ets_cache/phoenix.ex
@@ -5,10 +5,14 @@ if Code.ensure_loaded?(Phoenix.Controller) do
         import Phoenix.View, only: [render_to_string: 3]
 
         def cache_response(conn) do
-          cache_response(conn, nil)
+          cache_response(conn, [])
         end
 
-        def cache_response(conn, ttl) do
+        def cache_response(conn, ttl) when is_number(ttl) or is_atom(ttl) do
+          cache_response(conn, [ttl: ttl])
+        end
+
+        def cache_response(conn, opts) when is_list(opts) do
           content_type =
             conn
             |> Plug.Conn.get_resp_header("content-type")
@@ -30,7 +34,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           assigns = Map.merge(conn.assigns, %{conn: conn, layout: layout})
           response = render_to_string(view, template, assigns)
 
-          PlugEtsCache.Store.set(conn, content_type, response, ttl)
+          PlugEtsCache.Store.set(conn, content_type, response, opts)
           conn
         end
       end

--- a/lib/plug_ets_cache/plug.ex
+++ b/lib/plug_ets_cache/plug.ex
@@ -10,12 +10,17 @@ defmodule PlugEtsCache.Plug do
   """
 
   alias PlugEtsCache.Store
-  use Plug.Builder
+  import Plug.Conn
 
-  plug(:lookup)
 
-  def lookup(conn, _opts) do
-    case Store.get(conn) do
+  def init(opts) when is_list(opts) do
+    opts
+  end
+
+  def init(_), do: []
+
+  def call(conn, opts) do
+    case Store.get(conn, opts) do
       nil ->
         conn
 

--- a/lib/plug_ets_cache/store.ex
+++ b/lib/plug_ets_cache/store.ex
@@ -16,27 +16,43 @@ defmodule PlugEtsCache.Store do
   @doc """
   Retrieves eventual cached content based on `conn` params.
   """
-  def get(%Plug.Conn{} = conn) do
-    ConCache.get(db_name(), key(conn))
+  def get(%Plug.Conn{} = conn, opts \\ []) do
+    cache_key_fn = Keyword.get(opts, :cache_key, &key/1)
+    ConCache.get(db_name(), cache_key_fn.(conn))
   end
 
   @doc """
   Stores `conn` response data in the cache.
   """
   def set(%Plug.Conn{} = conn, type, value) when is_binary(value) do
-    set(conn, type, value, nil)
+    set(conn, type, value, [])
   end
 
   @doc """
   Stores `conn` response data in the cache with specified ttl.
   """
-  def set(%Plug.Conn{} = conn, type, value, ttl) when is_binary(value) do
+  def set(%Plug.Conn{} = conn, type, value, ttl) when is_binary(value) and (is_number(ttl) or is_atom(ttl)) do
+    set(conn, type, value, ttl: ttl)
+  end
+
+  @doc """
+  Stores `conn` response data in the cache with the specified options.
+
+  Recognized options:
+
+  - `ttl`, the ttl of the item (i.e `[ttl: 1_000]`)
+  - `cache_key`, a function taking one argument (the conn) that returns the key for to use for the item in the cache.
+  """
+  def set(%Plug.Conn{} = conn, type, value, opts) when is_list(opts) do
+    ttl = Keyword.get(opts, :ttl)
+    cache_key_fn = Keyword.get(opts, :cache_key, &key/1)
+
     item = case ttl do
       nil -> %{type: type, value: value}
       _else -> %ConCache.Item{value: %{type: type, value: value}, ttl: ttl}
     end
 
-    ConCache.put(db_name(), key(conn), item)
+    ConCache.put(db_name(), cache_key_fn.(conn), item)
     conn
   end
 

--- a/test/store_test.exs
+++ b/test/store_test.exs
@@ -20,4 +20,14 @@ defmodule PlugEtsCache.StoreTest do
     assert cache.value == "Hello cache"
     assert cache.type == "text/plain"
   end
+
+  test "sets and gets values from cache with custom key function" do
+    conn = %Plug.Conn{request_path: "/test", query_string: "?foo=bar"}
+    cache_key_fn = fn _conn -> "my_custom_key" end
+    PlugEtsCache.Store.set(conn, "text/plain", "Hello cache with custom key", [ttl: 1000, cache_key: cache_key_fn])
+    cache = PlugEtsCache.Store.get(conn, [cache_key: cache_key_fn])
+
+    assert cache.value == "Hello cache with custom key"
+    assert cache.type == "text/plain"
+  end
 end


### PR DESCRIPTION
I recently needed to cache something with a bit more control over the key.

This PR introduces a way to pass a custom function to generate the cache key. I've tried to preserve full backwards compatibility.